### PR TITLE
just-scripts: add target_platform&target_arch argument for just install

### DIFF
--- a/just-task.js
+++ b/just-task.js
@@ -3,15 +3,20 @@ const fs = require('fs')
 const download = require('download')
 const path = require('path')
 const downloadUrl = 'http://yx-web.nos.netease.com/package/1626234782/electron-tokenizer-plugin_v1.1.0.tar.gz'
+
 task('install', () => {
   return new Promise((resolve, reject) => {
     const localPath = path.join(__dirname, 'lib')
     download(downloadUrl, localPath, {
       extract: true
     }).then(() => {
+      const platform = process.env.npm_config_target_platform || process.platform
+      const arch = process.env.npm_config_target_arch || process.arch
       logger.info(`[install] Download prebuilt binaries from ${downloadUrl}`)
-      if (process.platform === 'win32') {
-        const src = path.join(localPath, process.arch, 'simple.dll')
+      logger.info(`[install] Target platform: ${platform}`)
+      logger.info(`[install] Target arch: ${arch}`)
+      if (platform === 'win32') {
+        const src = path.join(localPath, arch, 'simple.dll')
         const dst = path.join(localPath, 'simple.dll')
         logger.info(`Copy win32 lib from ${src} to ${dst}`)
         fs.copyFileSync(src, dst)


### PR DESCRIPTION
添加 target_platform 和 target_arch 参数提供 just install 使用，默认使用 node 运行时环境变量（process.platform 和 process.arch）

Signed-off-by: Dylan <2894220@gmail.com>